### PR TITLE
Enable graph node preview with obsidian api

### DIFF
--- a/src/components/relationship-graph-view.ts
+++ b/src/components/relationship-graph-view.ts
@@ -376,6 +376,25 @@ export class RelationshipGraphView extends ItemView {
 			this.cy.elements().removeClass("dim highlighted");
 		});
 
+		// Hover handler for preview popover
+		this.cy.on("mouseover", "node", (evt) => {
+			const node = evt.target;
+			const filePath = node.id();
+			const file = this.app.vault.getAbstractFileByPath(filePath);
+
+			if (file instanceof TFile) {
+				// Trigger Obsidian's hover preview
+				this.app.workspace.trigger("hover-link", {
+					event: evt.originalEvent,
+					source: VIEW_TYPE_RELATIONSHIP_GRAPH,
+					hoverParent: this,
+					targetEl: this.graphContainerEl,
+					linktext: file.path,
+					sourcePath: this.currentFile?.path || "",
+				});
+			}
+		});
+
 		// Click handler to open files
 		this.cy.on("tap", "node", (evt) => {
 			const node = evt.target;


### PR DESCRIPTION
Add native Obsidian hover preview to graph nodes to show file content on hover.

---
<a href="https://cursor.com/background-agent?bcId=bc-d242b3c0-94f8-46fd-b814-2e55ab5a3d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d242b3c0-94f8-46fd-b814-2e55ab5a3d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

